### PR TITLE
[fix/EstateDetailAddressPriceView] 주소 표시 안되는 버그 수정

### DIFF
--- a/KickIn/Core/Services/Location/GeocodeService.swift
+++ b/KickIn/Core/Services/Location/GeocodeService.swift
@@ -67,7 +67,7 @@ final class GeocodeService: GeocodeServiceProtocol {
 
         var components: [String] = []
         
-        if let administrativeArea { components.append(administrativeArea) }
+//        if let administrativeArea { components.append(administrativeArea) }
         if let locality { components.append(locality) }
         if let thoroughfare { components.append(thoroughfare) }
         if let subThoroughfare { components.append(subThoroughfare) }

--- a/KickIn/Features/EstateDetail/Views/Components/EstateDetailAddressPriceView.swift
+++ b/KickIn/Features/EstateDetail/Views/Components/EstateDetailAddressPriceView.swift
@@ -54,7 +54,7 @@ struct EstateDetailAddressPriceView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.bottom , 20)
         .padding(.horizontal, 20)
-        .task {
+        .task(id: "\(latitude ?? 0),\(longitude ?? 0)") {
             addressText = await geocodeService.getDetailedLocationString(latitude: latitude, longitude: longitude)
         }
     }


### PR DESCRIPTION
## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- 네트워크 응답 전에 geocoding이 실행되어 nil 값으로 처리되는 문제 해결
- .task를 .task(id:)로 변경하여 latitude/longitude 업데이트 시 자동 재실행
- GeocodeService에서 administrativeArea 제거로 주소 간결화

## 관련 이슈
Resolves #18 

## 타입

- [x] 버그 수정
- [ ] 새 기능
- [ ] 리팩토링
- [ ] UI 변경
- [ ] 기타

## 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [x] Warning 없음

## 스크린샷

<!-- 필요시 추가 -->
