### PR TITLE
[feat/ProfileView] 사용자 프로필 조회 및 표시

### DIFF
--- a/KickIn/Features/Profile/Models/UserProfileUIModel.swift
+++ b/KickIn/Features/Profile/Models/UserProfileUIModel.swift
@@ -1,0 +1,26 @@
+//
+//  UserProfileUIModel.swift
+//  KickIn
+//
+//  Created by 서준일 on 01/05/26.
+//
+
+import Foundation
+
+struct UserProfileUIModel {
+    let userId: String?
+    let nick: String?
+    let introduction: String?
+    let profileImage: String?
+}
+
+extension UserProfileResponseDTO {
+    func toUIModel() -> UserProfileUIModel {
+        return UserProfileUIModel(
+            userId: self.userId,
+            nick: self.nick,
+            introduction: self.introduction,
+            profileImage: self.profileImage
+        )
+    }
+}

--- a/KickIn/Features/Profile/ViewModels/ProfileViewModel.swift
+++ b/KickIn/Features/Profile/ViewModels/ProfileViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  ProfileViewModel.swift
+//  KickIn
+//
+//  Created by 서준일 on 01/05/26.
+//
+
+import Foundation
+import Combine
+import OSLog
+
+final class ProfileViewModel: ObservableObject {
+    @Published var userProfile: UserProfileUIModel?
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    private let networkService = NetworkServiceFactory.shared.makeNetworkService()
+
+    // MARK: - Public Methods
+
+    func loadMyProfile() async {
+        await MainActor.run {
+            isLoading = true
+            errorMessage = nil
+        }
+
+        do {
+            let response: UserProfileResponseDTO = try await networkService.request(UserRouter.myProfile)
+
+            let profile = response.toUIModel()
+
+            await MainActor.run {
+                self.userProfile = profile
+                self.isLoading = false
+            }
+
+            Logger.network.info("✅ Loaded user profile")
+
+        } catch let error as NetworkError {
+            Logger.network.error("❌ Failed to load user profile: \(error.localizedDescription)")
+            await MainActor.run {
+                self.errorMessage = error.localizedDescription
+                self.isLoading = false
+            }
+        } catch {
+            Logger.network.error("❌ Unknown error: \(error.localizedDescription)")
+            await MainActor.run {
+                self.errorMessage = "프로필을 불러오는데 실패했습니다."
+                self.isLoading = false
+            }
+        }
+    }
+}

--- a/KickIn/Features/Profile/Views/ProfileView.swift
+++ b/KickIn/Features/Profile/Views/ProfileView.swift
@@ -6,12 +6,110 @@
 //
 
 import SwiftUI
+import CachingKit
 
 struct ProfileView: View {
+    @StateObject private var viewModel = ProfileViewModel()
+    @Environment(\.cachingKit) private var cachingKit
+
     var body: some View {
-        Text("Profile View")
-            .navigationTitle("프로필")
-            .defaultBackground()
+        ScrollView {
+            if viewModel.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let profile = viewModel.userProfile {
+                VStack(spacing: 24) {
+                    // 프로필 이미지
+                    profileImageView(profile.profileImage)
+                        .padding(.top, 40)
+
+                    // 프로필 정보
+                    VStack(spacing: 12) {
+                        // 닉네임
+                        if let nick = profile.nick {
+                            Text(nick)
+                                .font(.body3(.pretendardBold))
+                                .foregroundStyle(Color.gray90)
+                        }
+
+                        // 소개글
+                        if let introduction = profile.introduction {
+                            Text(introduction)
+                                .font(.body2(.pretendardRegular))
+                                .foregroundStyle(Color.gray60)
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal, 20)
+                        }
+
+                        // 사용자 ID
+                        if let userId = profile.userId {
+                            Text("ID: \(userId)")
+                                .font(.caption1(.pretendardRegular))
+                                .foregroundStyle(Color.gray45)
+                        }
+                    }
+
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+            } else if let errorMessage = viewModel.errorMessage {
+                VStack(spacing: 12) {
+                    Text("프로필을 불러올 수 없습니다")
+                        .font(.body2(.pretendardBold))
+                        .foregroundStyle(Color.gray60)
+
+                    Text(errorMessage)
+                        .font(.caption1(.pretendardRegular))
+                        .foregroundStyle(Color.gray45)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle("프로필")
+        .defaultBackground()
+        .task {
+            await viewModel.loadMyProfile()
+        }
+    }
+}
+
+// MARK: - SubViews
+private extension ProfileView {
+    func profileImageView(_ profileImage: String?) -> some View {
+        Group {
+            if let profileImage = profileImage,
+               let imageURL = profileImage.thumbnailURL {
+                CachedAsyncImage(
+                    url: imageURL,
+                    targetSize: CGSize(width: 120, height: 120),
+                    cachingKit: cachingKit
+                ) { image in
+                    image
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 120, height: 120)
+                        .clipShape(Circle())
+                } placeholder: {
+                    Circle()
+                        .fill(Color.gray45)
+                        .frame(width: 120, height: 120)
+                        .overlay {
+                            ProgressView()
+                        }
+                }
+            } else {
+                Circle()
+                    .fill(Color.gray45)
+                    .frame(width: 120, height: 120)
+                    .overlay {
+                        Image(systemName: "person.fill")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 60, height: 60)
+                            .foregroundColor(.gray60)
+                    }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- UserProfileUIModel 추가 및 ResponseDTO 매핑 extension 구현
- ProfileViewModel 생성하여 myProfile API 호출 처리
- ProfileView에 CachingKit 기반 원형 프로필 이미지 표시
- 닉네임, 소개글, 사용자 ID 정보 표시
- 로딩 상태 및 에러 처리 추가

## 관련 이슈
Resolves #33 

## 타입

- [ ] 버그 수정
- [x] 새 기능
- [ ] 리팩토링
- [ ] UI 변경
- [ ] 기타

## 체크리스트

- [x] 빌드 성공
- [ ] 테스트 완료
- [ ] Warning 없음

## 스크린샷

<!-- 필요시 추가 -->
