### PR TITLE
refactor: 채팅 메시지 개선 및 싱크 작업 중 API 호출 최소화

### DIFF
--- a/KickIn/Core/Services/Socket/SocketService.swift
+++ b/KickIn/Core/Services/Socket/SocketService.swift
@@ -25,13 +25,17 @@ final class SocketService: SocketServiceProtocol {
     private var connectionContinuation: AsyncStream<Bool>.Continuation?
 
     lazy var messages: AsyncStream<ChatMessageItemDTO> = {
-        AsyncStream { [weak self] continuation in
+        Logger.chat.info("🔧 [SocketService] Creating messages AsyncStream (lazy init)")
+        return AsyncStream { [weak self] continuation in
+            Logger.chat.info("🔧 [SocketService] messages AsyncStream continuation initialized")
             self?.messageContinuation = continuation
         }
     }()
 
     lazy var connectionStates: AsyncStream<Bool> = {
-        AsyncStream { [weak self] continuation in
+        Logger.chat.info("🔧 [SocketService] Creating connectionStates AsyncStream (lazy init)")
+        return AsyncStream { [weak self] continuation in
+            Logger.chat.info("🔧 [SocketService] connectionStates AsyncStream continuation initialized")
             self?.connectionContinuation = continuation
         }
     }()
@@ -47,19 +51,25 @@ final class SocketService: SocketServiceProtocol {
     // MARK: - Public Methods
 
     func prepareNewConnection() {
+        Logger.chat.info("🔄 [SocketService] prepareNewConnection called")
+
         // 기존 스트림 종료
+        Logger.chat.info("🔄 [SocketService] Finishing existing continuations")
         messageContinuation?.finish()
         connectionContinuation?.finish()
 
         // 새 스트림 생성
+        Logger.chat.info("🔄 [SocketService] Creating new AsyncStreams")
         messages = AsyncStream { [weak self] continuation in
+            Logger.chat.info("🔄 [SocketService] New messages continuation initialized")
             self?.messageContinuation = continuation
         }
         connectionStates = AsyncStream { [weak self] continuation in
+            Logger.chat.info("🔄 [SocketService] New connectionStates continuation initialized")
             self?.connectionContinuation = continuation
         }
 
-        Logger.chat.info("🔄 New AsyncStreams prepared")
+        Logger.chat.info("🔄 [SocketService] New AsyncStreams prepared")
     }
 
     func connect(roomID: String) async {
@@ -171,8 +181,14 @@ final class SocketService: SocketServiceProtocol {
             }
 
             Logger.chat.info("✅ [SocketService] Decoded message, yielding to AsyncStream: \(message.chatId ?? "unknown")")
-            self.messageContinuation?.yield(message)
-            Logger.chat.info("✅ [SocketService] Message yielded to AsyncStream")
+
+            if self.messageContinuation == nil {
+                Logger.chat.error("❌ [SocketService] messageContinuation is nil! Cannot yield message.")
+            } else {
+                Logger.chat.info("✅ [SocketService] messageContinuation exists, yielding...")
+                self.messageContinuation?.yield(message)
+                Logger.chat.info("✅ [SocketService] Message yielded to AsyncStream")
+            }
         }
 
         // 에러

--- a/KickIn/Features/Chat/Views/ChatDetailView.swift
+++ b/KickIn/Features/Chat/Views/ChatDetailView.swift
@@ -14,8 +14,11 @@ struct ChatDetailView: View {
 
     let otherParticipantName: String
 
-    init(roomId: String, otherParticipantName: String) {
-        self._viewModel = StateObject(wrappedValue: ChatDetailViewModel(roomId: roomId))
+    init(roomId: String, opponentUserId: String, otherParticipantName: String) {
+        self._viewModel = StateObject(wrappedValue: ChatDetailViewModel(
+            roomId: roomId,
+            opponentUserId: opponentUserId
+        ))
         self.otherParticipantName = otherParticipantName
     }
 
@@ -48,15 +51,15 @@ struct ChatDetailView: View {
                                     myUserId: viewModel.myUserId
                                 )
                                 .id(item.id)
-                                .onAppear {
-                                    // 마지막 메시지에 도달하면 더 로드
-                                    if case .message(let lastConfig) = viewModel.chatItems.last,
-                                       lastConfig.id == config.id {
-                                        Task {
-                                            await viewModel.loadMoreMessages()
-                                        }
-                                    }
-                                }
+//                                .onAppear {
+//                                    // 마지막 메시지에 도달하면 더 로드
+//                                    if case .message(let lastConfig) = viewModel.chatItems.last,
+//                                       lastConfig.id == config.id {
+//                                        Task {
+//                                            await viewModel.loadMoreMessages()
+//                                        }
+//                                    }
+//                                }
                             }
                         }
                     }

--- a/KickIn/Features/Chat/Views/ChatRoomListView.swift
+++ b/KickIn/Features/Chat/Views/ChatRoomListView.swift
@@ -44,6 +44,7 @@ struct ChatRoomListView: View {
                         ForEach(viewModel.chatRooms) { chatRoom in
                             NavigationLink(destination: ChatDetailView(
                                 roomId: chatRoom.id,
+                                opponentUserId: chatRoom.otherParticipant.userId,
                                 otherParticipantName: chatRoom.otherParticipant.nickname
                             )) {
                                 ChatRoomCell(chatRoom: chatRoom)


### PR DESCRIPTION
## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- 채팅 로드 시 새로운 스트림을 구독하여 이전 스트림이 끊겨 수신이 됐음에도 버블이 생기지 않는 이슈 해결
    - 새로운 스트림을 제거하고 이전 스트림을 그대로 사용하도록 변경
- 상대방 Id를 사용하여 last Chat 요청하여 대조 후 렘과 같을 경우 동기화 작업 중지
- 동기화가 필요할 경우 채팅 목록을 호출하여 동기화 작업 수행
- 전송 실패한 임시 메세지의 경우 동기화 작업이 끝난 이후에 Realm과 UI에서 삭제하도록 함수 구현

## 관련 이슈
Resolves #39 

## 타입

- [x] 버그 수정
- [ ] 새 기능
- [x] 리팩토링
- [ ] UI 변경
- [ ] 기타

## 체크리스트

- [x] 빌드 성공
- [ ] 테스트 완료
- [ ] Warning 없음

## 스크린샷

<!-- 필요시 추가 -->
