### PR TITLE
[feat/EstateLike] 매물 좋아요 뷰 구성 및 로직 수행

### DIFF
--- a/KickIn/Features/EstateDetail/Models/EstateDetailUIModel.swift
+++ b/KickIn/Features/EstateDetail/Models/EstateDetailUIModel.swift
@@ -102,6 +102,38 @@ extension EstateDetailResponseDTO {
     }
 }
 
+extension EstateDetailUIModel {
+    func updating(isLiked: Bool?) -> EstateDetailUIModel {
+        return EstateDetailUIModel(
+            estateId: estateId,
+            category: category,
+            title: title,
+            introduction: introduction,
+            reservationPrice: reservationPrice,
+            thumbnails: thumbnails,
+            description: description,
+            deposit: deposit,
+            monthlyRent: monthlyRent,
+            builtYear: builtYear,
+            maintenanceFee: maintenanceFee,
+            area: area,
+            parkingCount: parkingCount,
+            floors: floors,
+            options: options,
+            geolocation: geolocation,
+            creator: creator,
+            isLiked: isLiked,
+            isReserved: isReserved,
+            likeCount: likeCount,
+            isSafeEstate: isSafeEstate,
+            isRecommended: isRecommended,
+            comments: comments,
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+    }
+}
+
 extension EstateOptionsDTO {
     func toUIModel() -> EstateOptionsUIModel {
         return EstateOptionsUIModel(

--- a/KickIn/Features/EstateDetail/ViewModels/EstateDetailViewModel.swift
+++ b/KickIn/Features/EstateDetail/ViewModels/EstateDetailViewModel.swift
@@ -29,6 +29,32 @@ final class EstateDetailViewModel: ObservableObject {
         await loadDetail()
         await loadSimilarEstates()
     }
+
+    func toggleLike() async {
+        let currentLikeStatus = estate?.isLiked ?? false
+        let nextLikeStatus = !currentLikeStatus
+
+        do {
+            let response: EstateLikeResponseDTO = try await networkService.request(
+                EstateRouter.likeEstate(
+                    estateId: estateId,
+                    EstateLikeRequestDTO(likeStatus: nextLikeStatus)
+                )
+            )
+
+            let updatedStatus = response.likeStatus ?? nextLikeStatus
+
+            await MainActor.run {
+                self.estate = self.estate?.updating(isLiked: updatedStatus)
+            }
+
+            Logger.network.info("✅ Updated estate like status: \(updatedStatus)")
+        } catch let error as NetworkError {
+            Logger.network.error("❌ Failed to update like status: \(error.localizedDescription)")
+        } catch {
+            Logger.network.error("❌ Unknown error updating like status: \(error.localizedDescription)")
+        }
+    }
 }
 
 // MARK: - Load Data

--- a/KickIn/Features/EstateDetail/Views/Components/EstateDetailAgentInfoView.swift
+++ b/KickIn/Features/EstateDetail/Views/Components/EstateDetailAgentInfoView.swift
@@ -60,7 +60,7 @@ struct EstateDetailAgentInfoView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.bottom, 60)
+        .padding(.bottom, 100)
     }
 }
 

--- a/KickIn/Features/EstateDetail/Views/EstateDetailView.swift
+++ b/KickIn/Features/EstateDetail/Views/EstateDetailView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct EstateDetailView: View {
     @StateObject private var viewModel: EstateDetailViewModel
     private let estateId: String
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     init(estateId: String) {
         self.estateId = estateId
@@ -17,6 +18,43 @@ struct EstateDetailView: View {
     }
     
     var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            detailScrollView()
+            if isRegularWidth {
+                floatingCTA()
+            }
+        }
+        .defaultBackground()
+        .toolbar(.hidden, for: .tabBar)
+        .safeAreaInset(edge: .bottom) {
+            if !isRegularWidth {
+                bottomCTA()
+            }
+        }
+        .navigationTitle(viewModel.estate?.title ?? "")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.loadData()
+        }
+    }
+
+    private var isRegularWidth: Bool {
+        horizontalSizeClass == .regular
+    }
+
+    private var likeIconName: String {
+        isLiked ? "Icon/Like_Fill" : "Icon/Like_Empty"
+    }
+
+    private var likeIconColor: Color {
+        isLiked ? Color.brightWood : Color.gray60
+    }
+
+    private var isLiked: Bool {
+        viewModel.estate?.isLiked ?? false
+    }
+
+    private func detailScrollView() -> some View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack(spacing: 0) {
                 EstateDetailTopImageView(thumbnails: viewModel.estate?.thumbnails)
@@ -68,14 +106,76 @@ struct EstateDetailView: View {
             }
             .frame(maxWidth: .infinity)
         }
-        .defaultBackground()
-        .navigationTitle(viewModel.estate?.title ?? "")
-        .navigationBarTitleDisplayMode(.inline)
-        .task {
-            await viewModel.loadData()
-        }
     }
-    
+
+    private func floatingCTA() -> some View {
+        HStack(spacing: 12) {
+            Button {
+                Task {
+                    await viewModel.toggleLike()
+                }
+            } label: {
+                Image(likeIconName)
+                    .renderingMode(.template)
+                    .foregroundStyle(likeIconColor)
+                    .frame(width: 32, height: 32)
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                // TODO: reserve action
+            } label: {
+                Text("예약하기")
+                    .font(.title1(.pretendardBold))
+                    .foregroundStyle(Color.gray0)
+                    .frame(minWidth: 120, minHeight: 48)
+                    .padding(.horizontal, 8)
+                    .background(Color.deepCream)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.ultraThinMaterial)
+        .clipShape(Capsule())
+        .shadow(color: .black.opacity(0.12), radius: 10, x: 0, y: 6)
+        .padding(.trailing, 24)
+        .padding(.bottom, 24)
+    }
+
+    private func bottomCTA() -> some View {
+        HStack(spacing: 12) {
+            Button {
+                Task {
+                    await viewModel.toggleLike()
+                }
+            } label: {
+                Image(likeIconName)
+                    .renderingMode(.template)
+                    .foregroundStyle(likeIconColor)
+                    .frame(width: 32, height: 32)
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                // TODO: reserve action
+            } label: {
+                Text("예약하기")
+                    .font(.title1(.pretendardBold))
+                    .foregroundStyle(Color.gray0)
+                    .frame(maxWidth: .infinity, minHeight: 48)
+                    .background(Color.deepCream)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(Color.gray0)
+        .shadow(color: .black.opacity(0.08), radius: 8, x: 0, y: -2)
+    }
+
     private func divider() -> some View {
         return Divider()
             .background(Color.gray30)


### PR DESCRIPTION
## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- 좋아요 토글 API 요청 연결
- 응답 상태로 isLiked 갱신
- CTA 아이콘 Empty/Fill 및 컬러 적용

## 관련 이슈
Resolves #48 

## 타입

- [ ] 버그 수정
- [x] 새 기능
- [ ] 리팩토링
- [x] UI 변경
- [ ] 기타

## 체크리스트

- [x] 빌드 성공
- [ ] 테스트 완료
- [ ] Warning 없음

## 스크린샷

<!-- 필요시 추가 -->
