### PR TITLE
[fix/Payment] 결제 화면이 열리기 전에 닫히는 버그 수정

### DIFF
--- a/KickIn/Features/EstateDetail/ViewModels/EstateDetailViewModel.swift
+++ b/KickIn/Features/EstateDetail/ViewModels/EstateDetailViewModel.swift
@@ -97,7 +97,7 @@ final class EstateDetailViewModel: ObservableObject {
                 )
             }
 
-            Logger.network.info("✅ Created order for estate ID: \(self.estateId)")
+            Logger.network.info("✅ Created order for estate ID: \(self.estateId), orderCode: \(orderCode)")
         } catch let error as NetworkError {
             Logger.network.error("❌ Failed to create order: \(error.localizedDescription)")
             await MainActor.run {


### PR DESCRIPTION
## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- retryPendingValidations()의 에러가 현재 결제 흐름에 영향을 주지 않도록 분리
- validateReceipt에 silent 파라미터 추가하여 retry 시 콜백 호출 방지
- 400 에러(유효하지 않은 결제건) 발생 시 pending에서 imp_uid 제거

## 관련 이슈
Resolves #68 

## 타입

- [x] 버그 수정
- [ ] 새 기능
- [ ] 리팩토링
- [ ] UI 변경
- [ ] 기타

## 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [ ] Warning 없음

## 스크린샷

<!-- 필요시 추가 -->
