### PR TITLE
[feat: ProfileView] 프로필 뷰 디자인 변경

### DIFF
--- a/KickIn/Features/Profile/Views/Components/ProfileErrorView.swift
+++ b/KickIn/Features/Profile/Views/Components/ProfileErrorView.swift
@@ -1,0 +1,52 @@
+//
+//  ProfileErrorView.swift
+//  KickIn
+//
+//  Created by 서준일 on 01/16/26
+//
+
+import SwiftUI
+
+struct ProfileErrorView: View {
+    let errorMessage: String
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(Color.gray45)
+
+            Text("프로필을 불러올 수 없습니다")
+                .font(.body1(.pretendardBold))
+                .foregroundStyle(Color.gray75)
+
+            Text(errorMessage)
+                .font(.body3(.pretendardRegular))
+                .foregroundStyle(Color.gray60)
+                .multilineTextAlignment(.center)
+
+            Button {
+                onRetry()
+            } label: {
+                Text("다시 시도")
+                    .font(.body3(.pretendardMedium))
+                    .foregroundStyle(Color.white)
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 12)
+                    .background(Color.deepCoast)
+                    .clipShape(Capsule())
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 400)
+        .padding(.horizontal, 20)
+    }
+}
+
+#Preview {
+    ProfileErrorView(
+        errorMessage: "네트워크 연결을 확인해주세요.",
+        onRetry: { }
+    )
+    .defaultBackground()
+}

--- a/KickIn/Features/Profile/Views/Components/ProfileHeaderView.swift
+++ b/KickIn/Features/Profile/Views/Components/ProfileHeaderView.swift
@@ -1,0 +1,115 @@
+//
+//  ProfileHeaderView.swift
+//  KickIn
+//
+//  Created by 서준일 on 01/16/26
+//
+
+import SwiftUI
+import CachingKit
+
+struct ProfileHeaderView: View {
+    let profile: UserProfileUIModel
+    let onEditProfile: () -> Void
+
+    @Environment(\.cachingKit) private var cachingKit
+
+    var body: some View {
+        VStack(spacing: 16) {
+            // 프로필 이미지
+            profileImageView(profile.profileImage)
+                .padding(.top, 24)
+
+            // 닉네임
+            Text(profile.nick ?? "사용자")
+                .font(.title1(.pretendardBold))
+                .foregroundStyle(Color.gray90)
+
+            // 소개글
+            if let introduction = profile.introduction, !introduction.isEmpty {
+                Text(introduction)
+                    .font(.body2(.pretendardRegular))
+                    .foregroundStyle(Color.gray60)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .padding(.horizontal, 40)
+            }
+
+            // 프로필 편집 버튼
+            Button {
+                onEditProfile()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "pencil")
+                        .font(.caption1(.pretendardMedium))
+                    Text("프로필 편집")
+                        .font(.body3(.pretendardMedium))
+                }
+                .foregroundStyle(Color.gray75)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 10)
+                .background(Color.gray30)
+                .clipShape(Capsule())
+            }
+            .padding(.top, 4)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 8)
+    }
+}
+
+// MARK: - Private Views
+private extension ProfileHeaderView {
+    func profileImageView(_ profileImage: String?) -> some View {
+        Group {
+            if let profileImage = profileImage,
+               let imageURL = profileImage.thumbnailURL {
+                CachedAsyncImage(
+                    url: imageURL,
+                    targetSize: CGSize(width: 100, height: 100),
+                    cachingKit: cachingKit
+                ) { image in
+                    image
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 100, height: 100)
+                        .clipShape(Circle())
+                        .overlay {
+                            Circle()
+                                .stroke(Color.gray30, lineWidth: 1)
+                        }
+                } placeholder: {
+                    Circle()
+                        .fill(Color.gray30)
+                        .frame(width: 100, height: 100)
+                        .overlay {
+                            ProgressView()
+                        }
+                }
+            } else {
+                Circle()
+                    .fill(Color.gray30)
+                    .frame(width: 100, height: 100)
+                    .overlay {
+                        Image(systemName: "person.fill")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 50, height: 50)
+                            .foregroundColor(.gray45)
+                    }
+            }
+        }
+    }
+}
+
+#Preview {
+    ProfileHeaderView(
+        profile: UserProfileUIModel(
+            userId: "test123",
+            nick: "테스트 사용자",
+            introduction: "안녕하세요. 테스트 소개글입니다.",
+            profileImage: nil
+        ),
+        onEditProfile: { }
+    )
+}

--- a/KickIn/Features/Profile/Views/Components/ProfileMenuRow.swift
+++ b/KickIn/Features/Profile/Views/Components/ProfileMenuRow.swift
@@ -1,0 +1,76 @@
+//
+//  ProfileMenuRow.swift
+//  KickIn
+//
+//  Created by 서준일 on 01/16/26
+//
+
+import SwiftUI
+
+struct ProfileMenuRow: View {
+    let icon: String
+    let title: String
+    var value: String? = nil
+    var titleColor: Color = .gray90
+    var showChevron: Bool = true
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: icon)
+                    .font(.body2(.pretendardRegular))
+                    .foregroundStyle(Color.gray60)
+                    .frame(width: 24)
+
+                Text(title)
+                    .font(.body2(.pretendardRegular))
+                    .foregroundStyle(titleColor)
+
+                Spacer()
+
+                if let value = value {
+                    Text(value)
+                        .font(.body3(.pretendardRegular))
+                        .foregroundStyle(Color.gray45)
+                }
+
+                if showChevron {
+                    Image(systemName: "chevron.right")
+                        .font(.caption1(.pretendardRegular))
+                        .foregroundStyle(Color.gray45)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    VStack(spacing: 0) {
+        ProfileMenuRow(
+            icon: "bell.fill",
+            title: "알림 설정",
+            action: { }
+        )
+
+        ProfileMenuRow(
+            icon: "info.circle.fill",
+            title: "앱 버전",
+            value: "1.0.0",
+            showChevron: false,
+            action: { }
+        )
+
+        ProfileMenuRow(
+            icon: "rectangle.portrait.and.arrow.right",
+            title: "로그아웃",
+            titleColor: .gray75,
+            showChevron: false,
+            action: { }
+        )
+    }
+    .background(Color.gray0)
+}

--- a/KickIn/Features/Profile/Views/Components/ProfileMenuSection.swift
+++ b/KickIn/Features/Profile/Views/Components/ProfileMenuSection.swift
@@ -1,0 +1,47 @@
+//
+//  ProfileMenuSection.swift
+//  KickIn
+//
+//  Created by 서준일 on 01/16/26
+//
+
+import SwiftUI
+
+struct ProfileMenuSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title)
+                .font(.caption1(.pretendardMedium))
+                .foregroundStyle(Color.gray60)
+                .padding(.horizontal, 4)
+                .padding(.bottom, 8)
+
+            VStack(spacing: 0) {
+                content()
+            }
+            .background(Color.gray0)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+}
+
+#Preview {
+    ProfileMenuSection(title: "설정") {
+        ProfileMenuRow(
+            icon: "bell.fill",
+            title: "알림 설정",
+            action: { }
+        )
+
+        ProfileMenuRow(
+            icon: "lock.fill",
+            title: "개인정보 설정",
+            action: { }
+        )
+    }
+    .padding()
+    .defaultBackground()
+}

--- a/KickIn/Features/Profile/Views/ProfileView.swift
+++ b/KickIn/Features/Profile/Views/ProfileView.swift
@@ -6,129 +6,140 @@
 //
 
 import SwiftUI
-import CachingKit
 
 struct ProfileView: View {
     @StateObject private var viewModel = ProfileViewModel()
-    @Environment(\.cachingKit) private var cachingKit
     @Environment(\.logoutAction) private var logoutAction
 
+    @State private var showLogoutAlert = false
+    @State private var showWithdrawAlert = false
+
     var body: some View {
-        ScrollView {
+        ScrollView(.vertical, showsIndicators: false) {
             if viewModel.isLoading {
                 ProgressView()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(maxWidth: .infinity, minHeight: 400)
             } else if let profile = viewModel.userProfile {
-                VStack(spacing: 24) {
-                    // 프로필 이미지
-                    profileImageView(profile.profileImage)
-                        .padding(.top, 40)
+                VStack(spacing: 0) {
+                    // MARK: - 프로필 헤더 섹션
+                    ProfileHeaderView(
+                        profile: profile,
+                        onEditProfile: {
+                            // TODO: 프로필 편집 화면으로 이동
+                        }
+                    )
 
-                    // 프로필 정보
+                    // MARK: - 메뉴 섹션들
                     VStack(spacing: 12) {
-                        // 닉네임
-                        if let nick = profile.nick {
-                            Text(nick)
-                                .font(.body3(.pretendardBold))
-                                .foregroundStyle(Color.gray90)
+                        // 일반 설정
+                        ProfileMenuSection(title: "설정") {
+                            ProfileMenuRow(
+                                icon: "bell.fill",
+                                title: "알림 설정",
+                                action: { }
+                            )
+
+                            ProfileMenuRow(
+                                icon: "lock.fill",
+                                title: "개인정보 설정",
+                                action: { }
+                            )
                         }
 
-                        // 소개글
-                        if let introduction = profile.introduction {
-                            Text(introduction)
-                                .font(.body2(.pretendardRegular))
-                                .foregroundStyle(Color.gray60)
-                                .multilineTextAlignment(.center)
-                                .padding(.horizontal, 20)
+                        // 고객 지원
+                        ProfileMenuSection(title: "고객 지원") {
+                            ProfileMenuRow(
+                                icon: "questionmark.circle.fill",
+                                title: "고객센터",
+                                action: { }
+                            )
+
+                            ProfileMenuRow(
+                                icon: "doc.text.fill",
+                                title: "이용약관",
+                                action: { }
+                            )
+
+                            ProfileMenuRow(
+                                icon: "hand.raised.fill",
+                                title: "개인정보 처리방침",
+                                action: { }
+                            )
                         }
 
-                        // 사용자 ID
-                        if let userId = profile.userId {
-                            Text("ID: \(userId)")
-                                .font(.caption1(.pretendardRegular))
-                                .foregroundStyle(Color.gray45)
+                        // 앱 정보
+                        ProfileMenuSection(title: "앱 정보") {
+                            ProfileMenuRow(
+                                icon: "info.circle.fill",
+                                title: "앱 버전",
+                                value: Bundle.main.appVersion,
+                                showChevron: false,
+                                action: { }
+                            )
+                        }
+
+                        // 계정 관리
+                        ProfileMenuSection(title: "계정 관리") {
+                            ProfileMenuRow(
+                                icon: "rectangle.portrait.and.arrow.right",
+                                title: "로그아웃",
+                                titleColor: .gray75,
+                                showChevron: false,
+                                action: { showLogoutAlert = true }
+                            )
+
+                            ProfileMenuRow(
+                                icon: "person.crop.circle.badge.minus",
+                                title: "회원 탈퇴",
+                                titleColor: .red,
+                                showChevron: false,
+                                action: { showWithdrawAlert = true }
+                            )
                         }
                     }
-
-                    // 로그아웃 버튼
-                    Button(action: {
-                        Task {
-                            await viewModel.logout()
-                            logoutAction()
-                        }
-                    }) {
-                        Text("로그아웃")
-                            .font(.body2(.pretendardBold))
-                            .foregroundStyle(Color.white)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 14)
-                            .background(Color.red)
-                            .cornerRadius(8)
-                    }
-                    .padding(.horizontal, 20)
-                    .padding(.top, 20)
-
-                    Spacer()
+                    .padding(.horizontal, 16)
+                    .padding(.top, 24)
+                    .padding(.bottom, 40)
                 }
-                .frame(maxWidth: .infinity)
             } else if let errorMessage = viewModel.errorMessage {
-                VStack(spacing: 12) {
-                    Text("프로필을 불러올 수 없습니다")
-                        .font(.body2(.pretendardBold))
-                        .foregroundStyle(Color.gray60)
-
-                    Text(errorMessage)
-                        .font(.caption1(.pretendardRegular))
-                        .foregroundStyle(Color.gray45)
+                ProfileErrorView(errorMessage: errorMessage) {
+                    Task {
+                        await viewModel.loadMyProfile()
+                    }
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .navigationTitle("프로필")
         .defaultBackground()
+        .navigationBarTitleDisplayMode(.inline)
         .task {
             await viewModel.loadMyProfile()
+        }
+        .alert("로그아웃", isPresented: $showLogoutAlert) {
+            Button("취소", role: .cancel) { }
+            Button("로그아웃", role: .destructive) {
+                Task {
+                    await viewModel.logout()
+                    logoutAction()
+                }
+            }
+        } message: {
+            Text("정말 로그아웃 하시겠습니까?")
+        }
+        .alert("회원 탈퇴", isPresented: $showWithdrawAlert) {
+            Button("취소", role: .cancel) { }
+            Button("탈퇴하기", role: .destructive) {
+                // TODO: 회원 탈퇴 로직 구현
+            }
+        } message: {
+            Text("회원 탈퇴 시 모든 데이터가 삭제됩니다.\n정말 탈퇴하시겠습니까?")
         }
     }
 }
 
-// MARK: - SubViews
-private extension ProfileView {
-    func profileImageView(_ profileImage: String?) -> some View {
-        Group {
-            if let profileImage = profileImage,
-               let imageURL = profileImage.thumbnailURL {
-                CachedAsyncImage(
-                    url: imageURL,
-                    targetSize: CGSize(width: 120, height: 120),
-                    cachingKit: cachingKit
-                ) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: 120, height: 120)
-                        .clipShape(Circle())
-                } placeholder: {
-                    Circle()
-                        .fill(Color.gray45)
-                        .frame(width: 120, height: 120)
-                        .overlay {
-                            ProgressView()
-                        }
-                }
-            } else {
-                Circle()
-                    .fill(Color.gray45)
-                    .frame(width: 120, height: 120)
-                    .overlay {
-                        Image(systemName: "person.fill")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 60, height: 60)
-                            .foregroundColor(.gray60)
-                    }
-            }
-        }
+// MARK: - Bundle Extension
+extension Bundle {
+    var appVersion: String {
+        infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
     }
 }
 


### PR DESCRIPTION
## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- 프로필 이미지, 닉네임, 소개글 표시
- 프로필 편집 버튼
- onEditProfile 클로저로 편집 액션 전달
- 메뉴 섹션 그룹화
- 재사용 가능한 메뉴 행 컴포넌트
- 아이콘, 타이틀, 값, chevron 표시 옵션
- 에러 상태 UI
- 재시도 버튼 포함
- onRetry 클로저로 재시도 액션 전달

## 관련 이슈
Resolves #77 

## 타입

- [ ] 버그 수정
- [x] 새 기능
- [x] 리팩토링
- [x] UI 변경
- [ ] 기타

## 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [ ] Warning 없음

## 스크린샷

<!-- 필요시 추가 -->
