### PR TITLE
[feat/ProfileEditView] 프로필 화면의 UX/UI를 개선하고, 프로필 편집 기능을 추가

### DIFF
--- a/KickIn/Features/Profile/ViewModels/ProfileEditViewModel.swift
+++ b/KickIn/Features/Profile/ViewModels/ProfileEditViewModel.swift
@@ -1,0 +1,128 @@
+//
+//  ProfileEditViewModel.swift
+//  KickIn
+//
+//  Created by 서준일 on 01/16/26
+//
+
+import Foundation
+import Combine
+import OSLog
+
+@MainActor
+final class ProfileEditViewModel: ObservableObject {
+    // MARK: - Published Properties
+    @Published var nick: String = ""
+    @Published var introduction: String = ""
+    @Published var phoneNum: String = ""
+    @Published var profileImage: String?
+    @Published var selectedImageData: Data?
+
+    @Published var isLoading: Bool = false
+    @Published var isSaving: Bool = false
+    @Published var uploadProgress: Double = 0.0
+    @Published var errorMessage: String?
+    @Published var showSuccessMessage: Bool = false
+
+    // MARK: - Private Properties
+    private let networkService: NetworkServiceProtocol
+
+    // MARK: - Initialization
+    init(networkService: NetworkServiceProtocol = NetworkServiceFactory.shared.makeNetworkService()) {
+        self.networkService = networkService
+    }
+
+    // MARK: - Public Methods
+
+    /// 프로필 정보 로드
+    func loadProfile() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let response: MyProfileResponseDTO = try await networkService.request(UserRouter.myProfile)
+
+            nick = response.nick ?? ""
+            introduction = response.introduction ?? ""
+            phoneNum = response.phoneNum ?? ""
+            profileImage = response.profileImage
+
+            Logger.profile.info("프로필 로드 성공")
+        } catch {
+            let networkError = error as? NetworkError ?? .unknown
+            errorMessage = networkError.localizedDescription
+            Logger.profile.error("프로필 로드 실패: \(error.localizedDescription)")
+        }
+
+        isLoading = false
+    }
+
+    /// 프로필 저장
+    func saveProfile() async -> Bool {
+        isSaving = true
+        errorMessage = nil
+
+        do {
+            // 1. 이미지가 선택된 경우 이미지 업로드
+            var uploadedImagePath: String? = profileImage
+
+            if let imageData = selectedImageData {
+                uploadedImagePath = try await uploadProfileImage(imageData)
+            }
+
+            // 2. 프로필 정보 업데이트
+            let requestDTO = UpdateProfileRequestDTO(
+                nick: nick.isEmpty ? nil : nick,
+                introduction: introduction.isEmpty ? nil : introduction,
+                phoneNum: phoneNum.isEmpty ? nil : phoneNum,
+                profileImage: uploadedImagePath
+            )
+
+            let _: MyProfileResponseDTO = try await networkService.request(
+                UserRouter.updateMyProfile(requestDTO)
+            )
+
+            Logger.profile.info("프로필 저장 성공")
+            showSuccessMessage = true
+            isSaving = false
+            return true
+
+        } catch {
+            let networkError = error as? NetworkError ?? .unknown
+            errorMessage = networkError.localizedDescription
+            Logger.profile.error("프로필 저장 실패: \(error.localizedDescription)")
+            isSaving = false
+            return false
+        }
+    }
+
+    // MARK: - Private Methods
+
+    /// 프로필 이미지 업로드
+    private func uploadProfileImage(_ imageData: Data) async throws -> String {
+        let fileSizeKB = Double(imageData.count) / 1024.0
+
+        let files = [(
+            data: imageData,
+            name: "profile",
+            fileName: "profile.jpg",
+            mimeType: "image/jpeg"
+        )]
+
+        let response: ProfileImageResponseDTO = try await networkService.uploadWithProgress(
+            UserRouter.uploadProfileImage,
+            files: files
+        ) { [weak self] progress in
+            self?.uploadProgress = progress
+            Logger.profile.debug("업로드 진행률: \(String(format: "%.1f", progress * 100))%")
+        }
+
+        guard let imagePath = response.profileImage else {
+            Logger.profile.error("응답에 이미지 경로 없음")
+            throw NetworkError.decodingError
+        }
+
+        Logger.profile.info("이미지 업로드 성공: \(imagePath)")
+        return imagePath
+    }
+}

--- a/KickIn/Features/Profile/Views/ProfileEditView.swift
+++ b/KickIn/Features/Profile/Views/ProfileEditView.swift
@@ -1,0 +1,316 @@
+//
+//  ProfileEditView.swift
+//  KickIn
+//
+//  Created by 서준일 on 01/16/26
+//
+
+import SwiftUI
+import CachingKit
+
+struct ProfileEditView: View {
+    @StateObject private var viewModel = ProfileEditViewModel()
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.cachingKit) private var cachingKit
+
+    @State private var showImagePicker = false
+    @State private var showCancelAlert = false
+
+    var body: some View {
+        NavigationStack {
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 32) {
+                    // MARK: - 프로필 이미지 섹션
+                    profileImageSection
+
+                    // MARK: - 입력 폼 섹션
+                    VStack(spacing: 20) {
+                        // 닉네임
+                        ProfileEditTextField(
+                            title: "닉네임",
+                            placeholder: "닉네임을 입력하세요",
+                            text: $viewModel.nick,
+                            maxLength: 20
+                        )
+
+                        // 소개글
+                        ProfileEditTextEditor(
+                            title: "소개",
+                            placeholder: "자기소개를 입력하세요",
+                            text: $viewModel.introduction,
+                            maxLength: 100
+                        )
+
+                        // 전화번호
+                        ProfileEditTextField(
+                            title: "전화번호",
+                            placeholder: "010-1234-5678",
+                            text: $viewModel.phoneNum,
+                            keyboardType: .phonePad,
+                            maxLength: 13
+                        )
+                    }
+                    .padding(.horizontal, 20)
+                }
+                .padding(.vertical, 24)
+            }
+            .defaultBackground()
+            .navigationTitle("프로필 편집")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("취소") {
+                        showCancelAlert = true
+                    }
+                    .foregroundStyle(Color.gray75)
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("저장") {
+                        Task {
+                            let success = await viewModel.saveProfile()
+                            if success {
+                                dismiss()
+                            }
+                        }
+                    }
+                    .font(.body2(.pretendardBold))
+                    .foregroundStyle(Color.deepCoast)
+                    .disabled(viewModel.isSaving || viewModel.nick.isEmpty)
+                }
+            }
+            .overlay {
+                if viewModel.isLoading {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(Color.black.opacity(0.1))
+                }
+            }
+            .overlay {
+                if viewModel.isSaving {
+                    VStack(spacing: 16) {
+                        ProgressView()
+                            .scaleEffect(1.2)
+
+                        if viewModel.uploadProgress > 0 && viewModel.uploadProgress < 1 {
+                            Text("이미지 업로드 중...")
+                                .font(.body3(.pretendardMedium))
+                                .foregroundStyle(Color.gray75)
+
+                            ProgressView(value: viewModel.uploadProgress)
+                                .frame(width: 200)
+                        } else {
+                            Text("저장 중...")
+                                .font(.body3(.pretendardMedium))
+                                .foregroundStyle(Color.gray75)
+                        }
+                    }
+                    .padding(24)
+                    .background(Color.gray0)
+                    .cornerRadius(12)
+                    .shadow(color: .black.opacity(0.1), radius: 10)
+                }
+            }
+            .alert("오류", isPresented: .constant(viewModel.errorMessage != nil)) {
+                Button("확인") {
+                    viewModel.errorMessage = nil
+                }
+            } message: {
+                if let errorMessage = viewModel.errorMessage {
+                    Text(errorMessage)
+                }
+            }
+            .alert("변경사항 취소", isPresented: $showCancelAlert) {
+                Button("계속 편집", role: .cancel) { }
+                Button("취소", role: .destructive) {
+                    dismiss()
+                }
+            } message: {
+                Text("편집한 내용이 저장되지 않습니다.")
+            }
+            .sheet(isPresented: $showImagePicker) {
+                ImagePicker(selectedImageData: $viewModel.selectedImageData)
+            }
+            .task {
+                await viewModel.loadProfile()
+            }
+        }
+    }
+}
+
+// MARK: - 프로필 이미지 섹션
+private extension ProfileEditView {
+    var profileImageSection: some View {
+        VStack(spacing: 12) {
+            ZStack(alignment: .bottomTrailing) {
+                // 프로필 이미지
+                Group {
+                    if let selectedImageData = viewModel.selectedImageData,
+                       let uiImage = UIImage(data: selectedImageData) {
+                        // 새로 선택한 이미지
+                        Image(uiImage: uiImage)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 120, height: 120)
+                            .clipShape(Circle())
+                            .overlay {
+                                Circle()
+                                    .stroke(Color.gray30, lineWidth: 1)
+                            }
+                    } else if let profileImage = viewModel.profileImage,
+                              let imageURL = profileImage.thumbnailURL {
+                        // 기존 이미지
+                        CachedAsyncImage(
+                            url: imageURL,
+                            targetSize: CGSize(width: 120, height: 120),
+                            cachingKit: cachingKit
+                        ) { image in
+                            image
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 120, height: 120)
+                                .clipShape(Circle())
+                                .overlay {
+                                    Circle()
+                                        .stroke(Color.gray30, lineWidth: 1)
+                                }
+                        } placeholder: {
+                            Circle()
+                                .fill(Color.gray30)
+                                .frame(width: 120, height: 120)
+                                .overlay {
+                                    ProgressView()
+                                }
+                        }
+                    } else {
+                        // 기본 이미지
+                        Circle()
+                            .fill(Color.gray30)
+                            .frame(width: 120, height: 120)
+                            .overlay {
+                                Image(systemName: "person.fill")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 60, height: 60)
+                                    .foregroundColor(.gray45)
+                            }
+                    }
+                }
+
+                // 편집 버튼
+                Button {
+                    showImagePicker = true
+                } label: {
+                    Circle()
+                        .fill(Color.deepCoast)
+                        .frame(width: 36, height: 36)
+                        .overlay {
+                            Image(systemName: "camera.fill")
+                                .font(.body3(.pretendardMedium))
+                                .foregroundStyle(Color.white)
+                        }
+                        .overlay {
+                            Circle()
+                                .stroke(Color.gray0, lineWidth: 2)
+                        }
+                }
+            }
+
+            Text("프로필 사진 변경")
+                .font(.caption1(.pretendardMedium))
+                .foregroundStyle(Color.gray60)
+        }
+    }
+}
+
+// MARK: - ProfileEditTextField
+struct ProfileEditTextField: View {
+    let title: String
+    let placeholder: String
+    @Binding var text: String
+    var keyboardType: UIKeyboardType = .default
+    var maxLength: Int = 100
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.body3(.pretendardMedium))
+                .foregroundStyle(Color.gray75)
+
+            TextField(placeholder, text: $text)
+                .font(.body2(.pretendardRegular))
+                .foregroundStyle(Color.gray90)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 14)
+                .background(Color.gray0)
+                .cornerRadius(8)
+                .keyboardType(keyboardType)
+                .onChange(of: text) { _, newValue in
+                    if newValue.count > maxLength {
+                        text = String(newValue.prefix(maxLength))
+                    }
+                }
+
+            HStack {
+                Spacer()
+                Text("\(text.count)/\(maxLength)")
+                    .font(.caption2(.pretendardRegular))
+                    .foregroundStyle(Color.gray45)
+            }
+        }
+    }
+}
+
+// MARK: - ProfileEditTextEditor
+struct ProfileEditTextEditor: View {
+    let title: String
+    let placeholder: String
+    @Binding var text: String
+    var maxLength: Int = 100
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.body3(.pretendardMedium))
+                .foregroundStyle(Color.gray75)
+
+            ZStack(alignment: .topLeading) {
+                if text.isEmpty {
+                    Text(placeholder)
+                        .font(.body2(.pretendardRegular))
+                        .foregroundStyle(Color.gray45)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 14)
+                }
+
+                TextEditor(text: $text)
+                    .font(.body2(.pretendardRegular))
+                    .foregroundStyle(Color.gray90)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .frame(minHeight: 100)
+                    .scrollContentBackground(.hidden)
+                    .background(Color.gray0)
+                    .cornerRadius(8)
+                    .onChange(of: text) { _, newValue in
+                        if newValue.count > maxLength {
+                            text = String(newValue.prefix(maxLength))
+                        }
+                    }
+            }
+            .background(Color.gray0)
+            .cornerRadius(8)
+
+            HStack {
+                Spacer()
+                Text("\(text.count)/\(maxLength)")
+                    .font(.caption2(.pretendardRegular))
+                    .foregroundStyle(Color.gray45)
+            }
+        }
+    }
+}
+
+#Preview {
+    ProfileEditView()
+}

--- a/KickIn/Features/Profile/Views/ProfileView.swift
+++ b/KickIn/Features/Profile/Views/ProfileView.swift
@@ -13,6 +13,7 @@ struct ProfileView: View {
 
     @State private var showLogoutAlert = false
     @State private var showWithdrawAlert = false
+    @State private var showEditProfile = false
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
@@ -25,7 +26,7 @@ struct ProfileView: View {
                     ProfileHeaderView(
                         profile: profile,
                         onEditProfile: {
-                            // TODO: 프로필 편집 화면으로 이동
+                            showEditProfile = true
                         }
                     )
 
@@ -132,6 +133,17 @@ struct ProfileView: View {
             }
         } message: {
             Text("회원 탈퇴 시 모든 데이터가 삭제됩니다.\n정말 탈퇴하시겠습니까?")
+        }
+        .sheet(isPresented: $showEditProfile) {
+            ProfileEditView()
+        }
+        .onChange(of: showEditProfile) { _, isPresented in
+            if !isPresented {
+                // 편집 화면이 닫힐 때 프로필 새로고침
+                Task {
+                    await viewModel.loadMyProfile()
+                }
+            }
         }
     }
 }

--- a/KickIn/Shared/Components/ImagePicker.swift
+++ b/KickIn/Shared/Components/ImagePicker.swift
@@ -1,0 +1,114 @@
+//
+//  ImagePicker.swift
+//  KickIn
+//
+//  Created by 서준일 on 01/16/26
+//
+
+import SwiftUI
+import PhotosUI
+import OSLog
+
+struct ImagePicker: UIViewControllerRepresentable {
+    @Binding var selectedImageData: Data?
+    @Environment(\.dismiss) private var dismiss
+
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var configuration = PHPickerConfiguration()
+        configuration.filter = .images
+        configuration.selectionLimit = 1
+        configuration.preferredAssetRepresentationMode = .current
+
+        let picker = PHPickerViewController(configuration: configuration)
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, PHPickerViewControllerDelegate {
+        let parent: ImagePicker
+
+        init(_ parent: ImagePicker) {
+            self.parent = parent
+        }
+
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            parent.dismiss()
+
+            guard let provider = results.first?.itemProvider else {
+                Logger.profile.debug("이미지 선택 취소됨")
+                return
+            }
+
+            Logger.profile.info("이미지 선택 시작")
+
+            if provider.canLoadObject(ofClass: UIImage.self) {
+                provider.loadObject(ofClass: UIImage.self) { [weak self] image, error in
+                    guard let self = self else { return }
+
+                    if let error = error {
+                        Logger.profile.error("이미지 로드 실패: \(error.localizedDescription)")
+                        return
+                    }
+
+                    guard let uiImage = image as? UIImage else {
+                        Logger.profile.error("UIImage 변환 실패")
+                        return
+                    }
+
+                    // JPEG로 변환
+                    guard let jpegData = self.convertToJPEG(uiImage) else {
+                        Logger.profile.error("JPEG 변환 실패")
+                        return
+                    }
+
+                    DispatchQueue.main.async {
+                        self.parent.selectedImageData = jpegData
+                    }
+                }
+            }
+        }
+
+        /// 이미지를 JPEG 포맷으로 변환
+        private func convertToJPEG(_ image: UIImage) -> Data? {
+            Logger.profile.debug("JPEG 변환 시작")
+
+            // 이미지가 너무 큰 경우 리사이징 (최대 1920px)
+            let resizedImage = resizeImageIfNeeded(image, maxDimension: 1920)
+
+            // JPEG로 변환 (품질 0.8)
+            guard let jpegData = resizedImage.jpegData(compressionQuality: 0.8) else {
+                return nil
+            }
+
+            let jpegSizeKB = Double(jpegData.count) / 1024.0
+            Logger.profile.info("JPEG 변환 성공 - 파일 크기: \(String(format: "%.2f", jpegSizeKB))KB")
+
+            return jpegData
+        }
+
+        /// 이미지가 너무 큰 경우 리사이징
+        private func resizeImageIfNeeded(_ image: UIImage, maxDimension: CGFloat) -> UIImage {
+            let size = image.size
+
+            // 이미지가 이미 작은 경우 원본 반환
+            if size.width <= maxDimension && size.height <= maxDimension {
+                return image
+            }
+
+            // 비율 유지하며 리사이징
+            let ratio = min(maxDimension / size.width, maxDimension / size.height)
+            let newSize = CGSize(width: size.width * ratio, height: size.height * ratio)
+
+            let renderer = UIGraphicsImageRenderer(size: newSize)
+            return renderer.image { _ in
+                image.draw(in: CGRect(origin: .zero, size: newSize))
+            }
+        }
+    }
+}

--- a/KickIn/Shared/Utilities/Logger+Extension.swift
+++ b/KickIn/Shared/Utilities/Logger+Extension.swift
@@ -27,6 +27,9 @@ extension Logger {
     /// 채팅 관련 로그 (메시지, SocketIO)
     nonisolated static let chat = Logger(subsystem: subsystem, category: "Chat")
 
+    /// 프로필 관련 로그 (프로필 조회, 수정, 이미지 업로드)
+    nonisolated static let profile = Logger(subsystem: subsystem, category: "Profile")
+
     /// 일반 로그
     nonisolated static let `default` = Logger(subsystem: subsystem, category: "Default")
 }


### PR DESCRIPTION
## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- ProfileView를 현대적인 디자인으로 재구성 (카드형 메뉴 섹션)
- 컴포넌트 기반으로 코드 분리 (ProfileHeaderView, ProfileMenuRow 등)
- 프로필 편집 화면 구현 (이미지 업로드, 닉네임/소개글/전화번호 수정)
- 로그아웃/회원탈퇴 확인 Alert 추가
- 에러 상태 UI 개선 (재시도 버튼 포함)

## 관련 이슈
Resolves #81

## 타입

- [ ] 버그 수정
- [x] 새 기능
- [ ] 리팩토링
- [x] UI 변경
- [ ] 기타

## 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [ ] Warning 없음

## 스크린샷

<!-- 필요시 추가 -->
