### PR TITLE
[feat/Chat-retry] 채팅 메시지 전송 실패 시 재전송/삭제 기능 추가

### DIFF
--- a/KickIn/Features/Chat/Views/Components/ChatMessageBubble.swift
+++ b/KickIn/Features/Chat/Views/Components/ChatMessageBubble.swift
@@ -218,11 +218,43 @@ struct ChatMessageBubble: View {
             }
 
             if message.sendFailed {
-                Text("전송 실패")
-                    .font(.caption2(.pretendardMedium))
-                    .foregroundColor(.red)
-                    .padding(.horizontal, 12)
-                    .padding(.bottom, 8)
+                HStack(spacing: 8) {
+                    Text("전송 실패")
+                        .font(.caption2(.pretendardMedium))
+                        .foregroundColor(.red)
+
+                    HStack(spacing: 4) {
+                        // 재전송 버튼
+                        Button {
+                            Task {
+                                await viewModel.retryFailedMessage(chatId: message.id)
+                            }
+                        } label: {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundColor(.white)
+                                .frame(width: 24, height: 24)
+                                .background(Color.deepCream)
+                                .clipShape(Circle())
+                        }
+
+                        // 삭제 버튼
+                        Button {
+                            Task {
+                                await viewModel.deleteFailedMessage(chatId: message.id)
+                            }
+                        } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundColor(.white)
+                                .frame(width: 24, height: 24)
+                                .background(Color.gray60)
+                                .clipShape(Circle())
+                        }
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.bottom, 8)
             }
         }
     }


### PR DESCRIPTION
## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- 전송 실패한 메시지에 재전송 및 삭제 버튼 표시

## 관련 이슈
Resolves #

## 타입

- [ ] 버그 수정
- [x] 새 기능
- [ ] 리팩토링
- [x] UI 변경
- [ ] 기타

## 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [ ] Warning 없음

## 스크린샷

<!-- 필요시 추가 -->
