### PR TITLE
[refactor/chat-bubble] 링크 프리뷰 카드 최대 너비 제한 및 레이아웃 개선

### DIFF
--- a/KickIn/Features/Chat/Models/MessageDisplayConfig.swift
+++ b/KickIn/Features/Chat/Models/MessageDisplayConfig.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 /// 채팅 메시지의 UI 표시 설정을 관리하는 모델
-/// 카카오톡 스타일 연속 메시지 처리: 프로필 숨김, 시간 최적화
 struct MessageDisplayConfig: Identifiable, Hashable {
     let id: String
     let message: ChatMessageUIModel

--- a/KickIn/Features/Chat/Views/Components/LinkPreviewCard.swift
+++ b/KickIn/Features/Chat/Views/Components/LinkPreviewCard.swift
@@ -16,6 +16,11 @@ struct LinkPreviewCard: View {
     let isSentByMe: Bool
     let hasTextAbove: Bool
 
+    // 채팅 버블의 최대 너비
+    private var maxWidth: CGFloat {
+        UIScreen.main.bounds.width * 0.70
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // 오픈 그래프 이미지
@@ -23,14 +28,12 @@ struct LinkPreviewCard: View {
                let imageURL = URL(string: imageURLString.hasPrefix("http") ? imageURLString : "https:\(imageURLString)") {
                 CachedAsyncImage(
                     url: imageURL,
-                    targetSize: CGSize(width: 300, height: 180),
+                    targetSize: CGSize(width: maxWidth, height: 180),
                     cachingKit: cachingKit
                 ) { image in
                     image
                         .resizable()
                         .scaledToFill()
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 180)
                         .clipped()
                 } placeholder: {
                     Rectangle()
@@ -69,7 +72,7 @@ struct LinkPreviewCard: View {
                     Text(title)
                         .font(.body2(.pretendardBold))
                         .foregroundColor(.gray90)
-                        .lineLimit(2)
+                        .lineLimit(1)
                 }
 
                 // 설명
@@ -77,11 +80,13 @@ struct LinkPreviewCard: View {
                     Text(description)
                         .font(.caption1(.pretendardRegular))
                         .foregroundColor(.gray75)
-                        .lineLimit(3)
+                        .lineLimit(2)
                 }
             }
-            .padding(12)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.bottom, 12)
+            .padding(.top, metadata.imageURL != nil ? 12 : 0)
+            .frame(maxWidth: maxWidth, alignment: .leading)
             .background(isSentByMe ? Color.deepCream : Color.white.opacity(0.95))
         }
         .background(isSentByMe ? Color.deepCream : Color.white.opacity(0.95))
@@ -93,5 +98,6 @@ struct LinkPreviewCard: View {
                 topTrailingRadius: hasTextAbove ? 0 : 12
             )
         )
+        .frame(maxWidth: maxWidth, alignment: .leading)
     }
 }

--- a/KickIn/Features/Chat/Views/Components/MessageImageGrid.swift
+++ b/KickIn/Features/Chat/Views/Components/MessageImageGrid.swift
@@ -16,7 +16,7 @@ struct MessageImageGrid: View {
     let isSentByMe: Bool
     let onImageTap: (MediaItem, Int) -> Void
 
-    // 채팅 버블의 최대 너비 (카카오톡 스타일: 화면의 55%)
+    // 채팅 버블의 최대 너비
     private var maxWidth: CGFloat {
         UIScreen.main.bounds.width * 0.55
     }


### PR DESCRIPTION
## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- LinkPreviewCard 최대 너비를 화면의 55%로 제한
- 링크 프리뷰 존재 시 메시지 텍스트에서 URL 자동 제거
- hasTextAbove 계산 로직 개선하여 실제 표시 텍스트 기준으로 판단
- .cornerRadius를 .clipShape(RoundedRectangle)로 변경하여 정확한 클리핑
- CachedAsyncImage targetSize로 이미지 크기 지정, 내부 frame 제거
- 이미지 없는 링크 프리뷰의 상단 패딩 조건부 제거

## 관련 이슈
Resolves #114 

## 타입

- [ ] 버그 수정
- [ ] 새 기능
- [x] 리팩토링
- [x] UI 변경
- [ ] 기타

## 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [ ] Warning 없음

## 스크린샷

<!-- 필요시 추가 -->
