### PR TITLE
refactor: iPad 대응을 위한 EstateDetail 레이아웃 조정

### DIFF
--- a/KickIn/Features/EstateDetail/Views/Components/EstateDetailOptionView.swift
+++ b/KickIn/Features/EstateDetail/Views/Components/EstateDetailOptionView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct EstateDetailOptionView: View {
     let options: EstateOptionsUIModel?
     let parkingCount: Int?
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     private let optionItems: [(name: String, iconName: String)] = [
         ("냉장고", "Option/Refrigerator"),
@@ -21,6 +22,10 @@ struct EstateDetailOptionView: View {
         ("싱크대", "Option/Sink"),
         ("TV", "Option/Television")
     ]
+
+    private var isRegularWidth: Bool {
+        horizontalSizeClass == .regular
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -52,7 +57,8 @@ struct EstateDetailOptionView: View {
 private extension EstateDetailOptionView {
 
     var optionGridView: some View {
-        let columns = Array(repeating: GridItem(.flexible(), spacing: 16), count: 4)
+        let columnCount = isRegularWidth ? 8 : 4
+        let columns = Array(repeating: GridItem(.flexible(), spacing: 16), count: columnCount)
 
         return LazyVGrid(columns: columns, spacing: 16) {
             ForEach(optionItems, id: \.name) { item in

--- a/KickIn/Features/EstateDetail/Views/EstateDetailView.swift
+++ b/KickIn/Features/EstateDetail/Views/EstateDetailView.swift
@@ -142,6 +142,7 @@ struct EstateDetailView: View {
                     creator: viewModel.estate?.creator
                 )
             }
+            .frame(maxWidth: isRegularWidth ? 800 : .infinity)
             .frame(maxWidth: .infinity)
         }
     }


### PR DESCRIPTION
## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- EstateDetailOptionView 옵션 그리드를 regular width에서 8칼럼으로 변경하여 한 줄로 표시
- EstateDetailView 콘텐츠 최대 너비 800pt 제한 및 중앙 정렬

## 관련 이슈
Resolves #116 

## 타입

- [ ] 버그 수정
- [ ] 새 기능
- [x] 리팩토링
- [x] UI 변경
- [ ] 기타

## 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [ ] Warning 없음

## 스크린샷

<!-- 필요시 추가 -->
